### PR TITLE
OPENEUROPA-496: Add Coding Standards documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ For more information please check:
 
 - [OpenEuropa components](docs/openeuropa-components.md)
 - [How to contribute](docs/how-to-contribute.md)
+- [Coding standards](docs/coding-standards.md)
 
 [1]: https://ec.europa.eu/info/departments/informatics
 [2]: https://opensource.org

--- a/docs/coding-standards.md
+++ b/docs/coding-standards.md
@@ -5,20 +5,20 @@ In order for all contributions and components to look and feel familiar
 OpenEuropa has agreed on a set of coding standards that all contributors must follow.
 
 Although OpenEuropa does not define any coding standard as such, all the standards it follows
-are usually based on well known standards such as [PSR-1][1], [PSR-2][2] and [PSR-4][3].
+are usually based on well known standards such as [PSR-1][1] and [PSR-2][2].
 
 The following are a list of coding standards guidelines, 
-defined using [IETF RFC 2119][4] conformance keywords:
+defined using [IETF RFC 2119][3] conformance keywords:
 
 ## How to make your code follow the Coding Standards
 
 In order to make it easier for contributors to create new components or to modify existing ones
-the [Code Review][5] component has been created.
+the [Code Review][4] component has been created.
 
-Coding standards MUST be validated using the [OpenEuropa Code Review](https://github.com/openeuropa/code-review) component
+Coding standards MUST be validated using the OpenEuropa Code Review component
 across all different components on OpenEuropa.
 
-Please refer to the Code Review Readme for more information on usage.
+Please refer to the Code Review [documentation][5] for more information on usage.
 
 ## Coding Standards on Drupal Components
 
@@ -27,14 +27,13 @@ This applies to all files available in both modules and themes.
 
 ## Coding Standards on PHP based components
 
-All PHP based components that are not part of the Drupal ecosystem MUST adhere to the [Symfony][7] standards.
+All PHP based components that are not part of the Drupal ecosystem MUST adhere to the [PSR-2][2] standards.
 This applies to any library or component that is mainly developed on PHP
 
 
 [1]: https://www.php-fig.org/psr/psr-1/
 [2]: https://www.php-fig.org/psr/psr-2/
-[3]: https://www.php-fig.org/psr/psr-4/
-[4]: https://www.ietf.org/rfc/rfc2119.txt
-[5]: https://github.com/openeuropa/code-review
+[3]: https://www.ietf.org/rfc/rfc2119.txt
+[4]: https://github.com/openeuropa/code-review
+[5]: https://github.com/openeuropa/code-review/blob/master/README.md
 [6]: https://www.drupal.org/docs/develop/standards
-[7]: https://symfony.com/doc/current/contributing/code/standards.html

--- a/docs/coding-standards.md
+++ b/docs/coding-standards.md
@@ -7,29 +7,34 @@ OpenEuropa has agreed on a set of coding standards that all contributors must fo
 Although OpenEuropa does not define any coding standard as such, all the standards it follows
 are usually based on well known standards such as [PSR-1][1], [PSR-2][2] and [PSR-4][3].
 
+The following are a list of coding standards guidelines, 
+defined using [IETF RFC 2119][4] conformance keywords:
+
 ## How to make your code follow the Coding Standards
 
 In order to make it easier for contributors to create new components or to modify existing ones
-the [Code Review][4] component has been created.
+the [Code Review][5] component has been created.
 
-This component should be added to the dependency list of any other existing component on OpenEuropa
-and it will make sure that all the appropriate standards are followed.
+Coding standards MUST be validated using the [OpenEuropa Code Review](https://github.com/openeuropa/code-review) component
+across all different components on OpenEuropa.
+
 Please refer to the Code Review Readme for more information on usage.
 
 ## Coding Standards on Drupal Components
 
-All Drupal based components must follow the already defined [Drupal Coding Standards][5].
+All Drupal based components MUST follow the already defined [Drupal Coding Standards][6].
 This applies to all files available in both modules and themes.
 
 ## Coding Standards on PHP based components
 
-All PHP based components that are not part of the Drupal ecosystem must adhere to the [Symfony][6] standards.
+All PHP based components that are not part of the Drupal ecosystem MUST adhere to the [Symfony][7] standards.
 This applies to any library or component that is mainly developed on PHP
 
 
 [1]: https://www.php-fig.org/psr/psr-1/
 [2]: https://www.php-fig.org/psr/psr-2/
 [3]: https://www.php-fig.org/psr/psr-4/
-[4]: https://github.com/openeuropa/code-review
-[5]: https://www.drupal.org/docs/develop/standards
-[6]: https://symfony.com/doc/current/contributing/code/standards.html
+[4]: https://www.ietf.org/rfc/rfc2119.txt
+[5]: https://github.com/openeuropa/code-review
+[6]: https://www.drupal.org/docs/develop/standards
+[7]: https://symfony.com/doc/current/contributing/code/standards.html

--- a/docs/coding-standards.md
+++ b/docs/coding-standards.md
@@ -1,0 +1,35 @@
+# Coding Standards in OpenEuropa
+
+OpenEuropa and all its components are built with public contribution in mind. 
+In order for all contributions and components to look and feel familiar
+OpenEuropa has agreed on a set of coding standards that all contributors must follow.
+
+Although OpenEuropa does not define any coding standard as such, all the standards it follows
+are usually based on well known standards such as [PSR-1][1], [PSR-2][2] and [PSR-4][3].
+
+## How to make your code follow the Coding Standards
+
+In order to make it easier for contributors to create new components or to modify existing ones
+the [Code Review][4] component has been created.
+
+This component should be added to the dependency list of any other existing component on OpenEuropa
+and it will make sure that all the appropriate standards are followed.
+Please refer to the Code Review Readme for more information on usage.
+
+## Coding Standards on Drupal Components
+
+All Drupal based components must follow the already defined [Drupal Coding Standards][5].
+This applies to all files available in both modules and themes.
+
+## Coding Standards on PHP based components
+
+All PHP based components that are not part of the Drupal ecosystem must adhere to the [Symfony][6] standards.
+This applies to any library or component that is mainly developed on PHP
+
+
+[1]: https://www.php-fig.org/psr/psr-1/
+[2]: https://www.php-fig.org/psr/psr-2/
+[3]: https://www.php-fig.org/psr/psr-4/
+[4]: https://github.com/openeuropa/code-review
+[5]: https://www.drupal.org/docs/develop/standards
+[6]: https://symfony.com/doc/current/contributing/code/standards.html


### PR DESCRIPTION
## OPENEUROPA-496
### Description

Define and document coding standards and guidelines to be followed by OpenEuropa components and site implementations.

### Changelog

- Added: Add Coding Standards documentation.