### PR TITLE
OPENEUROPA-557: Add OpenEuropa Multilingual to Drupal components.

### DIFF
--- a/docs/openeuropa-components.md
+++ b/docs/openeuropa-components.md
@@ -101,6 +101,17 @@ All code is distributed on [Packagist][3] and released under the [EUPL-1.2 licen
             <a title="Downloads" href="https://packagist.org/packages/openeuropa/oe_paragraphs"><img src="https://img.shields.io/packagist/dt/openeuropa/oe_paragraphs.svg?maxAge=3600"/></a>
         </td>
     </tr>
+    <tr>
+        <td>
+            <a title="Repository" href="https://github.com/openeuropa/oe_multilingual"><b>OpenEuropa Multilingual</b></a><br/>
+            Multilingual features for the OpenEuropa project.
+        </td>
+        <td width="250">
+            <a title="Version" href="https://packagist.org/packages/openeuropa/oe_multilingual"><img src="https://img.shields.io/packagist/v/openeuropa/oe_multilingual.svg?maxAge=3600"/></a>      
+            <a title="Build" href="https://drone.fpfis.eu/openeuropa/oe_multilingual"><img src="https://drone.fpfis.eu/api/badges/openeuropa/oe_multilingual/status.svg?branch=master"/></a>
+            <a title="Downloads" href="https://packagist.org/packages/openeuropa/oe_multilingual"><img src="https://img.shields.io/packagist/dt/openeuropa/oe_multilingual.svg?maxAge=3600"/></a>
+        </td>
+    </tr>
 </table>
 
 [1]: http://www.php-fig.org


### PR DESCRIPTION
### Description

This PR will add the OE Multilingual module to the list of Drupal components
