### PR TITLE
OPENEUROPA-336: Add OpenEuropa Webtools to Drupal components.

### DIFF
--- a/docs/openeuropa-components.md
+++ b/docs/openeuropa-components.md
@@ -134,6 +134,17 @@ All code is distributed on [Packagist][3] and released under the [EUPL-1.2 licen
             <a title="Downloads" href="https://packagist.org/packages/openeuropa/oe_profile"><img src="https://img.shields.io/packagist/dt/openeuropa/oe_profile.svg?maxAge=3600"/></a>
         </td>
     </tr>
+    <tr>
+        <td>
+            <a title="Repository" href="https://github.com/openeuropa/oe_webtools"><b>OpenEuropa Webtools</b></a><br/>
+            Drupal module providing webtools analytics integration such as Matomo (formerly PIWIK).
+        </td>
+        <td width="250">
+            <a title="Version" href="https://packagist.org/packages/openeuropa/oe_webtools"><img src="https://img.shields.io/packagist/v/openeuropa/oe_webtools.svg?maxAge=3600"/></a>      
+            <a title="Build" href="https://drone.fpfis.eu/openeuropa/oe_webtools"><img src="https://drone.fpfis.eu/api/badges/openeuropa/oe_webtools/status.svg?branch=master"/></a>
+            <a title="Downloads" href="https://packagist.org/packages/openeuropa/oe_webtools"><img src="https://img.shields.io/packagist/dt/openeuropa/oe_profile.svg?maxAge=3600"/></a>
+        </td>
+    </tr>
 </table>
 
 


### PR DESCRIPTION
Add OpenEuropa Webtools to Drupal components.